### PR TITLE
Use exact dependency version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches: [ vnext, release ]
     paths-ignore:
       - '**/*.md'
-      - '**/*.txt'
       - '**/*.config'
       - '**/*.ini'
       - '**/*.fbx'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(FetchContent)
 
 FetchContent_Declare(DirectXMath
                      GIT_REPOSITORY https://github.com/NcStudios/DirectXMath.git
-                     GIT_TAG        origin/release
+                     GIT_TAG        21b8256207a68d413c517f97391f8354e5211692 # origin/release
                      GIT_SHALLOW    TRUE
 )
 
@@ -59,7 +59,8 @@ FetchContent_Declare(DirectXMath
 set(FMT_INSTALL ON)
 FetchContent_Declare(fmt
                      GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-                     GIT_TAG        fc07217d85e6dcec52878807d6bbd89a9d9156a5
+                     GIT_TAG        10.1.1
+                     GIT_SHALLOW    TRUE
 )
 
 FetchContent_MakeAvailable(DirectXMath fmt)


### PR DESCRIPTION
part of [#422](https://github.com/NcStudios/NcEngine/issues/422)

Targeting exact versions of dependencies so we can always build from previous commits.

Also CI build was set to ignore changes just to .txt file, and it didn't fire here. Removing that ignore.